### PR TITLE
fix TS2497 error

### DIFF
--- a/visualization/src/visualizers/AstVisualizer.tsx
+++ b/visualization/src/visualizers/AstVisualizer.tsx
@@ -15,7 +15,7 @@ import { observer, disposeOnUnmount } from "mobx-react";
 import { observable, autorun, trace } from "mobx";
 import * as monaco from "monaco-editor";
 import { getLanguageId } from "./text-visualizers/MonacoTextVisualizer";
-import * as LineColumn from "line-column";
+import LineColumn from "line-column";
 
 export class AstVisualizer extends Visualizer {
 	visualize(data: ExtractedData, collector: VisualizationCollector): void {


### PR DESCRIPTION
```
C:\dev\vscode-debug-visualizer\visualization>yarn build -p tsconfig.json
yarn run v1.17.3
warning package.json: No license field
$ tsc -p tsconfig.json
src/visualizers/AstVisualizer.tsx:18:29 - error TS2497: This module can only be referenced with ECMAScript imports/exports by turning on the 'allowSyntheticDefaultImports' flag and referencing its default export.

18 import * as LineColumn from "line-column";
                               ~~~~~~~~~~~~~


Found 1 error.
```

This fixes the above error.