### PR TITLE
add visualization to build steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
 		"./visualization-playground"
 	],
 	"scripts": {
-		"build": "yarn build-data-extraction && yarn build-extension && yarn build-ui",
+		"build": "yarn build-data-extraction && yarn build-extension && yarn build-visualization && yarn build-ui",
 		"build-data-extraction": "yarn workspace @hediet/debug-visualizer-data-extraction build",
 		"build-extension": "yarn workspace debug-visualizer build",
+		"build-visualization": "yarn workspace @hediet/visualization build",
 		"build-ui": "yarn workspace debug-visualizer-webview build"
 	}
 }


### PR DESCRIPTION
build-ui depends on `@hediet/visualization` so I added it to the build steps.

This fixes the below error:

```
C:\dev\vscode-debug-visualizer>yarn build-ui
yarn run v1.17.3
$ yarn workspace debug-visualizer-webview build
warning package.json: No license field
$ webpack

C:\dev\vscode-debug-visualizer\node_modules\ts-node\src\index.ts:421
    return new TSError(diagnosticText, diagnosticCodes)
           ^
TSError: ⨯ Unable to compile TypeScript:
webpack.config.ts:7:36 - error TS2307: Cannot find module '@hediet/visualization'.

7 import { EnabledVisualizers } from "@hediet/visualization";
                                     ~~~~~~~~~~~~~~~~~~~~~~~

    at createTSError (C:\dev\vscode-debug-visualizer\node_modules\ts-node\src\index.ts:421:12)
    at reportTSError (C:\dev\vscode-debug-visualizer\node_modules\ts-node\src\index.ts:425:19)
    at getOutput (C:\dev\vscode-debug-visualizer\node_modules\ts-node\src\index.ts:530:36)
    at Object.compile (C:\dev\vscode-debug-visualizer\node_modules\ts-node\src\index.ts:735:32)
    at Module.m._compile (C:\dev\vscode-debug-visualizer\node_modules\ts-node\src\index.ts:814:43)
    at Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Object.require.extensions.(anonymous function) [as .ts] (C:\dev\vscode-debug-visualizer\node_modules\ts-node\src\index.ts:817:12)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (C:\dev\vscode-debug-visualizer\node_modules\v8-compile-cache\v8-compile-cache.js:161:20)
    at Object.<anonymous> (C:\dev\vscode-debug-visualizer\webview\webpack.config.js:2:18)
    at Module._compile (C:\dev\vscode-debug-visualizer\node_modules\v8-compile-cache\v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (C:\dev\vscode-debug-visualizer\node_modules\v8-compile-cache\v8-compile-cache.js:161:20)
    at WEBPACK_OPTIONS (C:\dev\vscode-debug-visualizer\node_modules\webpack-cli\bin\utils\convert-argv.js:114:13)
    at requireConfig (C:\dev\vscode-debug-visualizer\node_modules\webpack-cli\bin\utils\convert-argv.js:116:6)
    at C:\dev\vscode-debug-visualizer\node_modules\webpack-cli\bin\utils\convert-argv.js:123:17
    at Array.forEach (<anonymous>)
    at module.exports (C:\dev\vscode-debug-visualizer\node_modules\webpack-cli\bin\utils\convert-argv.js:121:15)
    at yargs.parse (C:\dev\vscode-debug-visualizer\node_modules\webpack-cli\bin\cli.js:71:45)
    at Object.parse (C:\dev\vscode-debug-visualizer\node_modules\webpack-cli\node_modules\yargs\yargs.js:567:18)
    at C:\dev\vscode-debug-visualizer\node_modules\webpack-cli\bin\cli.js:49:8
    at Object.<anonymous> (C:\dev\vscode-debug-visualizer\node_modules\webpack-cli\bin\cli.js:366:3)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed.
Exit code: 1
Command: C:\Program Files\nodejs\node.exe
Arguments: C:\Program Files (x86)\Yarn\lib\cli.js build
Directory: C:\dev\vscode-debug-visualizer\webview
Output:

info Visit https://yarnpkg.com/en/docs/cli/workspace for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```