### PR TITLE
Generate object graph visualization in a fully language-agnostic way in GenericEvaluator

### DIFF
--- a/demos/java/.project
+++ b/demos/java/.project
@@ -1,17 +1,28 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-  <name>java</name>
-  <comment/>
-  <projects>&#xD;
-    </projects>
-  <buildSpec>
-    <buildCommand>
-      <name>org.eclipse.jdt.core.javabuilder</name>
-      <arguments>&#xD;
-            </arguments>
-    </buildCommand>
-  </buildSpec>
-  <natures>
-    <nature>org.eclipse.jdt.core.javanature</nature>
-  </natures>
+	<name>java</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1599063072264</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/extension/src/EvaluationWatchService/EvaluationEngine/GenericEvaluationEngine.ts
+++ b/extension/src/EvaluationWatchService/EvaluationEngine/GenericEvaluationEngine.ts
@@ -1,6 +1,4 @@
 import {
-	createGraph,
-	CreateGraphEdge,
 	DataExtractionResult,
 	DataExtractorId,
 	GraphNode,

--- a/extension/src/EvaluationWatchService/EvaluationEngine/GenericEvaluationEngine.ts
+++ b/extension/src/EvaluationWatchService/EvaluationEngine/GenericEvaluationEngine.ts
@@ -108,7 +108,7 @@ export class GenericEvaluator implements Evaluator {
 		rootLabel: string,
 		rootVariablesReference: number,
 		maxDepth: number = 30,
-		maxKnownNodes: number = 100,
+		maxKnownNodes: number = 50,
 	): Promise<GraphVisualizationData> {
 		// Perform a breadth-first search on the object to construct the graph
 

--- a/extension/src/EvaluationWatchService/EvaluationEngine/GenericEvaluationEngine.ts
+++ b/extension/src/EvaluationWatchService/EvaluationEngine/GenericEvaluationEngine.ts
@@ -1,4 +1,6 @@
 import {
+	createGraph,
+	CreateGraphEdge,
 	DataExtractionResult,
 	DataExtractorId,
 } from "@hediet/debug-visualizer-data-extraction";
@@ -49,6 +51,8 @@ export class GenericEvaluator implements Evaluator {
 			// Use structural information about variables
 			// from the evaluation response if present.
 			if (reply.variablesReference) {
+				let obj = await this.constructObjectFromVariablesReference(reply.variablesReference);
+
 				return {
 					kind: "data",
 					result: {
@@ -58,7 +62,30 @@ export class GenericEvaluator implements Evaluator {
 							name: "Generic",
 							priority: 1,
 						},
-						data: await this.constructObjectFromVariablesReference(reply.variablesReference),
+						data: createGraph(
+							[obj],
+							(item: any) => {
+								function isObject(val: any): boolean {
+									return val && typeof val === "object";
+								}
+
+								const edges = new Array<CreateGraphEdge<any>>();
+								for (const [key, val] of Object.entries(item)) {
+									if (isObject(val)) {
+										edges.push({ label: key, to: val });
+									}
+								}
+
+								const label = `${item}`;
+
+								return {
+									shape: "box",
+									edges,
+									color: item === obj ? "lightblue" : undefined,
+									label,
+								};
+							}
+						),
 					},
 				}
 			} else {

--- a/extension/src/EvaluationWatchService/EvaluationEngine/GenericEvaluationEngine.ts
+++ b/extension/src/EvaluationWatchService/EvaluationEngine/GenericEvaluationEngine.ts
@@ -40,7 +40,7 @@ export class GenericEvaluator implements Evaluator {
 			expression,
 			preferredExtractorId,
 		});
-		let reply;
+		let reply: { result: string, variablesReference: number };
 		try {
 			reply = await this.session.evaluate({
 				expression: finalExpression,
@@ -76,12 +76,13 @@ export class GenericEvaluator implements Evaluator {
 									}
 								}
 
-								const label = `${item}`;
+								const isTopLevel = item === obj;
+								const label = isObject(item) ? "object" : `${item}`;
 
 								return {
 									shape: "box",
 									edges,
-									color: item === obj ? "lightblue" : undefined,
+									color: isTopLevel ? "lightblue" : undefined,
 									label,
 								};
 							}

--- a/extension/src/debugger/EnhancedDebugSession.ts
+++ b/extension/src/debugger/EnhancedDebugSession.ts
@@ -46,6 +46,23 @@ export class EnhancedDebugSession {
 		}
 	}
 
+	public async getVariables(args: {
+		variablesReference: number
+	}): Promise<Variable[]> {
+		try {
+			const reply = await this.session.customRequest("variables", {
+				variablesReference: args.variablesReference
+			});
+			if (!reply) {
+				return [];
+			}
+			return reply.variables;
+		} catch (error) {
+			console.error(error);
+			return [];
+		}
+	}
+
 	/**
 	 * Evaluates the given expression.
 	 * If context is "watch", long results are usually shortened.
@@ -64,6 +81,13 @@ export class EnhancedDebugSession {
 		return { result: reply.result, variablesReference: reply.variablesReference };
 	}
 }
+
+interface Variable {
+	name: string;
+	value: string;
+	variablesReference: number;
+}
+
 interface StackFrame {
 	id: number;
 	name: string;

--- a/extension/src/debugger/EnhancedDebugSession.ts
+++ b/extension/src/debugger/EnhancedDebugSession.ts
@@ -55,13 +55,13 @@ export class EnhancedDebugSession {
 		expression: string;
 		frameId: number | undefined;
 		context: "watch" | "repl" | "copy";
-	}): Promise<{ result: string }> {
+	}): Promise<{ result: string, variablesReference: number }> {
 		const reply = await this.session.customRequest("evaluate", {
 			expression: args.expression,
 			frameId: args.frameId,
 			context: args.context,
 		});
-		return { result: reply.result };
+		return { result: reply.result, variablesReference: reply.variablesReference };
 	}
 }
 interface StackFrame {


### PR DESCRIPTION
### Fixes #83 

As proposed in the issue, this PR generates a graph visualization of the program's state purely from Debug Adapter Protocol information, thereby making it possible (in theory) to visualize _every_ language that can be debugged using VSCode.

Example using Kotlin:

![image](https://user-images.githubusercontent.com/30873659/92023001-6970dd80-ed5c-11ea-93fa-37239c6854a2.png)
 