### PR TITLE
Add a Dart demo script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -70,6 +70,12 @@
 			},
 			"outFiles": ["${workspaceFolder}/extension/dist/**/*.js"],
 			"preLaunchTask": "npm: dev - extension"
-		}
+		},
+		{
+			"type": "dart",
+			"request": "launch",
+			"name": "Run Dart samples",
+			"program": "demos/dart/demo.dart"
+		},
 	]
 }

--- a/demos/dart/debug_visualizers.dart
+++ b/demos/dart/debug_visualizers.dart
@@ -1,0 +1,85 @@
+import 'dart:convert';
+
+String graph(List<GraphNode> nodes, List<GraphEdge> edges) {
+  return jsonEncode({
+    'kind': {'graph': true},
+    'nodes': nodes,
+    'edges': edges,
+  });
+}
+
+String plotly(List<num> values) {
+  return jsonEncode({
+    'kind': {'plotly': true},
+    'data': [
+      {'y': values}
+    ],
+  });
+}
+
+String tree(TreeNode root) {
+  return jsonEncode({
+    'kind': {'tree': true},
+    'root': root,
+  });
+}
+
+class Graph {
+  List<GraphNode> nodes;
+  List<GraphEdge> edges;
+}
+
+class GraphEdge {
+  final String from;
+  final String to;
+  final String label;
+
+  GraphEdge(this.from, this.to, this.label);
+
+  Map<String, dynamic> toJson() => {
+        'from': from,
+        'to': to,
+        'label': label,
+      };
+}
+
+class GraphNode {
+  final String id;
+  final String label;
+
+  GraphNode(
+    this.id,
+    this.label,
+  );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'label': label,
+      };
+}
+
+class TreeNode {
+  final List<TreeNode> children;
+  final List<TreeNodeItem> items;
+  final String segment;
+  final bool isMarked;
+
+  TreeNode(this.children, this.items, this.segment, [this.isMarked = false]);
+
+  Map<String, dynamic> toJson() => {
+        'children': children ?? [],
+        'items': items,
+        'segment': segment,
+        'isMarked': isMarked,
+      };
+}
+
+class TreeNodeItem {
+  final String text;
+
+  TreeNodeItem(this.text);
+
+  Map<String, dynamic> toJson() => {
+        'text': text,
+      };
+}

--- a/demos/dart/demo.dart
+++ b/demos/dart/demo.dart
@@ -1,0 +1,83 @@
+import 'dart:collection';
+import 'dart:developer';
+import 'dart:math';
+
+// ignore: unused_import
+import 'debug_visualizers.dart';
+
+final _rnd = Random();
+
+String Function() visualize;
+
+void main() {
+  debugger();
+  // Open a Debug Visualizer window and evalute the expression "visualize()"
+  // and then press Continue to step through the samples.
+  plotly_demo();
+  graph_demo();
+  tree_demo();
+}
+
+void plotly_demo() {
+  final values = <int>[];
+  visualize = () => plotly(values);
+  for (var i = 0; i < 20; i++) {
+    debugger();
+    values.add(i + _rnd.nextInt(5) - 2);
+  }
+}
+
+void graph_demo() {
+  graphFromDoubleLinked<T>(
+      DoubleLinkedQueue<T> values, String Function(T) toString) {
+    node(T s) => GraphNode(toString(s), toString(s));
+    edge(DoubleLinkedQueueEntry<T> e) => [
+          if (e.nextEntry() != null)
+            GraphEdge(
+              toString(e.element),
+              toString(e.nextEntry().element),
+              "next",
+            ),
+          if (e.previousEntry() != null)
+            GraphEdge(
+              toString(e.element),
+              toString(e.previousEntry().element),
+              "prev",
+            ),
+        ];
+
+    final nodes = values.map(node).toList();
+    final edges = <GraphEdge>[];
+    values.forEachEntry((e) => edges.addAll(edge(e)));
+    return graph(nodes, edges);
+  }
+
+  final values = DoubleLinkedQueue<String>();
+  visualize = () => graphFromDoubleLinked(values, (s) => s);
+
+  for (var i = 0; i < 10; i++) {
+    debugger();
+    values.addLast('Node $i');
+  }
+}
+
+void tree_demo() {
+  var nodeNum = 1;
+  TreeNode createNode(int levels) {
+    final name = 'Node ${nodeNum++}';
+    final children =
+        levels > 0 ? List.generate(2, (_) => createNode(levels - 1)) : null;
+    return TreeNode(children, [TreeNodeItem(name)], name);
+  }
+
+  var levels = 0;
+  visualize = () {
+    nodeNum = 1;
+    return tree(createNode(levels));
+  };
+
+  for (var i = 1; i < 5; i++) {
+    debugger();
+    levels = i;
+  }
+}

--- a/extension/README.md
+++ b/extension/README.md
@@ -16,6 +16,7 @@ Click [here](https://hediet.github.io/visualization/) to explore all available v
 See [demos](../demos/) for demos. These languages and debuggers are verified to work with this extension:
 
 -   JavaScript/TypeScript/... using `node`/`node2`/`extensionHost`/`chrome`/`pwa-chrome`/`pwa-node` debug adapter: [⭐ Full Support](../demos/js)
+-   Dart/Flutter using `dart` debug adapter: [✅ Rudimentary Support](../demos/dart)
 -   Go using `go` (Delve) debug adapter: [✅ Rudimentary Support](../demos/golang)
 -   Python using `python` debug adapter: [✅ Rudimentary Support](../demos/python)
 -   C# using `coreclr` debug adapter: [✅ Rudimentary Support](../demos/csharp) (work in progress for Full Support)


### PR DESCRIPTION
I created a small demo script in Dart that renders charts, graphs and trees:

![viz](https://user-images.githubusercontent.com/1078012/93870276-decd2f80-fcc4-11ea-9e62-44ad335e3e5a.gif)

Feel free to tweak, or let me know if there's anything I can do to improve it.

Thanks!

(Fixes #86?)