### PR TITLE
Register InlineValuesProvider to get the frame id

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -7,7 +7,7 @@
 	"version": "2.4.0",
 	"license": "GPL-3.0",
 	"engines": {
-		"vscode": "^1.46.0"
+		"vscode": "^1.55.0"
 	},
 	"publisher": "hediet",
 	"keywords": [
@@ -138,7 +138,7 @@
 		"@types/express": "^4.17.2",
 		"@types/serve-static": "^1.13.3",
 		"@types/node": "^13.7.4",
-		"@types/vscode": "1.46.0",
+		"@types/vscode": "1.55.0",
 		"tslint": "^6.0.0",
 		"typescript": "^3.8.2",
 		"webpack": "^4.41.6",

--- a/extension/src/VisualizationBackend/ConfigurableVisualizationSupport.ts
+++ b/extension/src/VisualizationBackend/ConfigurableVisualizationSupport.ts
@@ -7,7 +7,7 @@ import {
 import { Config, DebugAdapterConfig } from "../Config";
 import { GenericVisualizationBackend } from "./GenericVisualizationSupport";
 import { registerUpdateReconciler, hotClass } from "@hediet/node-reload";
-import { DebuggerViewProxy } from "../proxies/DebuggerViewProxy";
+import { DebuggerViewProxy, FrameIdGetter } from "../proxies/DebuggerViewProxy";
 
 registerUpdateReconciler(module);
 
@@ -16,7 +16,8 @@ export class ConfigurableVisualizationSupport
 	implements DebugSessionVisualizationSupport {
 	constructor(
 		private readonly config: Config,
-		private readonly debuggerView: DebuggerViewProxy
+		private readonly debuggerView: DebuggerViewProxy,
+		private readonly frameIdGetter: FrameIdGetter
 	) {}
 
 	createBackend(
@@ -29,7 +30,8 @@ export class ConfigurableVisualizationSupport
 		return new ConfiguredVisualizationBackend(
 			session,
 			this.debuggerView,
-			config
+			config,
+			this.frameIdGetter
 		);
 	}
 }
@@ -38,9 +40,10 @@ class ConfiguredVisualizationBackend extends GenericVisualizationBackend {
 	constructor(
 		debugSession: DebugSessionProxy,
 		debuggerView: DebuggerViewProxy,
-		private readonly config: DebugAdapterConfig
+		private readonly config: DebugAdapterConfig,
+		frameIdGetter: FrameIdGetter
 	) {
-		super(debugSession, debuggerView);
+		super(debugSession, debuggerView, frameIdGetter);
 	}
 
 	protected getContext() {

--- a/extension/src/VisualizationBackend/JsVisualizationSupport.ts
+++ b/extension/src/VisualizationBackend/JsVisualizationSupport.ts
@@ -10,7 +10,7 @@ import { existsSync, readFileSync, watch } from "fs";
 import { observable, reaction } from "mobx";
 import { window, workspace } from "vscode";
 import { Config } from "../Config";
-import { DebuggerViewProxy } from "../proxies/DebuggerViewProxy";
+import { DebuggerViewProxy, FrameIdGetter } from "../proxies/DebuggerViewProxy";
 import { DebugSessionProxy } from "../proxies/DebugSessionProxy";
 import { FormattedMessage } from "../webviewContract";
 import {
@@ -29,7 +29,8 @@ registerUpdateReconciler(module);
 export class JsEvaluationEngine implements DebugSessionVisualizationSupport {
 	constructor(
 		private readonly debuggerView: DebuggerViewProxy,
-		private readonly config: Config
+		private readonly config: Config,
+		private readonly frameIdGetter: FrameIdGetter
 	) {}
 
 	createBackend(
@@ -51,7 +52,8 @@ export class JsEvaluationEngine implements DebugSessionVisualizationSupport {
 			return new JsVisualizationBackend(
 				session,
 				this.debuggerView,
-				this.config
+				this.config,
+				this.frameIdGetter
 			);
 		}
 		return undefined;
@@ -65,9 +67,10 @@ class JsVisualizationBackend extends VisualizationBackendBase {
 	constructor(
 		debugSession: DebugSessionProxy,
 		debuggerView: DebuggerViewProxy,
-		private readonly config: Config
+		private readonly config: Config,
+		frameIdGetter: FrameIdGetter
 	) {
-		super(debugSession, debuggerView);
+		super(debugSession, debuggerView, frameIdGetter);
 	}
 
 	private getContext(): "copy" | "repl" {
@@ -112,7 +115,7 @@ class JsVisualizationBackend extends VisualizationBackendBase {
 		| { kind: "not-initialized" }
 	> {
 		try {
-			const frameId = this.debuggerView.getActiveStackFrameId(
+			const frameId = this.frameIdGetter.frameId || this.debuggerView.getActiveStackFrameId(
 				this.debugSession
 			);
 

--- a/extension/src/VisualizationBackend/VisualizationBackend.ts
+++ b/extension/src/VisualizationBackend/VisualizationBackend.ts
@@ -6,7 +6,7 @@ import { Disposable } from "@hediet/std/disposable";
 import { DebugSessionProxy } from "../proxies/DebugSessionProxy";
 import { CompletionItem, FormattedMessage } from "../webviewContract";
 import { reaction } from "mobx";
-import { DebuggerViewProxy } from "../proxies/DebuggerViewProxy";
+import { DebuggerViewProxy, FrameIdGetter } from "../proxies/DebuggerViewProxy";
 import { EventEmitter, EventSource } from "@hediet/std/events";
 
 export interface DebugSessionVisualizationSupport {
@@ -44,7 +44,8 @@ export abstract class VisualizationBackendBase implements VisualizationBackend {
 
 	constructor(
 		protected readonly debugSession: DebugSessionProxy,
-		protected readonly debuggerView: DebuggerViewProxy
+		protected readonly debuggerView: DebuggerViewProxy,
+		protected readonly frameIdGetter: FrameIdGetter
 	) {
 		this.dispose.track({
 			dispose: reaction(

--- a/extension/src/proxies/DebuggerViewProxy.ts
+++ b/extension/src/proxies/DebuggerViewProxy.ts
@@ -1,5 +1,5 @@
 import { Disposable } from "@hediet/std/disposable";
-import { debug, DebugSession } from "vscode";
+import { CancellationToken, debug, DebugSession, InlineValue, InlineValueContext, InlineValuesProvider, ProviderResult, Range, TextDocument } from "vscode";
 import { observable, action } from "mobx";
 import { DebuggerProxy } from "./DebuggerProxy";
 import { DebugSessionProxy } from "./DebugSessionProxy";
@@ -38,4 +38,16 @@ export class DebuggerViewProxy {
 			? this.debuggerProxy.getDebugSessionProxy(activeSession)
 			: undefined;
 	}
+}
+
+export class FrameIdGetter implements InlineValuesProvider, CurFrameIdGetter {
+	frameId: number | undefined;
+	provideInlineValues(document: TextDocument, viewPort: Range, context: InlineValueContext, token: CancellationToken): ProviderResult<InlineValue[]> {
+		this.frameId = context.frameId;
+		return []
+	}
+}
+
+interface CurFrameIdGetter {
+	readonly frameId: number | undefined;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -994,10 +994,10 @@
   dependencies:
     source-map "^0.6.1"
 
-"@types/vscode@1.46.0":
-  version "1.46.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.46.0.tgz#53f2075986e901ed25cd1ec5f3ffa5db84a111b3"
-  integrity sha512-8m9wPEB2mcRqTWNKs9A9Eqs8DrQZt0qNFO8GkxBOnyW6xR//3s77SoMgb/nY1ctzACsZXwZj3YRTDsn4bAoaUw==
+"@types/vscode@1.55.0":
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.55.0.tgz#58cfbebbd32b3e374e07e7858b1fd0e92b1a1d2b"
+  integrity sha512-49hysH7jneTQoSC8TWbAi7nKK9Lc5osQNjmDHVosrcU8o3jecD9GrK0Qyul8q4aGPSXRfNGqIp9CBdb13akETg==
 
 "@types/webpack-sources@*":
   version "0.1.6"


### PR DESCRIPTION
Fixes https://github.com/hediet/vscode-debug-visualizer/issues/169.

I could not confirm that this change worked in https://github.com/hediet/vscode-debug-visualizer/commit/904d0060eaa9e233e994f7757204b54ac93115a8 since `yarn build` failed. However, I could confirm that this change worked before it when I experimented in Ruby script.