### PR TITLE
fix python debugging issues after vscode was updated to version 1.87.0.

### DIFF
--- a/extension/src/VisualizationBackend/PyVisualizationSupport.ts
+++ b/extension/src/VisualizationBackend/PyVisualizationSupport.ts
@@ -27,7 +27,7 @@ export class PyEvaluationEngine implements DebugSessionVisualizationSupport {
 	createBackend(
 		session: DebugSessionProxy
 	): VisualizationBackend | undefined {
-		const supportedDebugAdapters = ["python"];
+		const supportedDebugAdapters = ["python", "debugpy"];
 
 		if (supportedDebugAdapters.indexOf(session.session.type) !== -1) {
 			return new PyVisualizationBackend(


### PR DESCRIPTION
The visualization failed because the python debug type was changed to "debugpy" after vscode was updated.