### PR TITLE
add debugpy to supportedDebugAdapters of PyEvaluationEngine

### DIFF
--- a/extension/src/VisualizationBackend/PyVisualizationSupport.ts
+++ b/extension/src/VisualizationBackend/PyVisualizationSupport.ts
@@ -27,7 +27,7 @@ export class PyEvaluationEngine implements DebugSessionVisualizationSupport {
 	createBackend(
 		session: DebugSessionProxy
 	): VisualizationBackend | undefined {
-		const supportedDebugAdapters = ["python"];
+		const supportedDebugAdapters = ["python", "debugpy"];
 
 		if (supportedDebugAdapters.indexOf(session.session.type) !== -1) {
 			return new PyVisualizationBackend(


### PR DESCRIPTION
Hi, i have taken Interest in this extension because i have to work a lot with python shapely geometries. I was preparing new visualizers in the `vscodedebugvisualizer` python package that is being injected by the `PyEvaluationEngine` when i found that it only expects a `python` debugging adapter. However this seems to have changed. When i debug python in vscode the debugging adapter is called `debugpy`.

This may explan some of the python related issues like [this one](https://github.com/hediet/vscode-debug-visualizer/issues/242) or [that one](https://github.com/hediet/vscode-debug-visualizer/issues/240). In my eyes the latter should work without a dedicated json formatter function because that should be injected through `vscodedebugvisualizer` by the `PyEvaluationEngine`.
It seems like the extension falls back to another evauation engine and tries to show the output data like it would be shown in a debug console.

I added `debugpy` to the supportedDebugAdapters,  built and ran the extension with the given `Run Extension (Dev UI)` configuration and it works as intended in the provided demo.py:
![image](https://github.com/user-attachments/assets/225e7187-304f-44e8-935b-5a069294b630)

Feel free to give me feedback and correct me if i got something wrong.